### PR TITLE
Remove Contentful hook

### DIFF
--- a/aas.py
+++ b/aas.py
@@ -47,17 +47,8 @@ class GitHub(Resource):
 
         response_payload = request.get_json()
 
-        if "ref" in response_payload:
-            pushed_branch = response_payload["ref"]
-            deploy_branch = os.environ["DEPLOY_REF"]
+        deploy_static_sticky()
 
-            if pushed_branch == "refs/heads/" + deploy_branch:
-                deploy_static_sticky()
-                return Response(status=200)
-            else:
-                return Response(status=202)
-        else:
-            abort(400)
 
 class Pretix(Resource):
     TOKEN = os.environ["PRETIX_TOKEN"]

--- a/aas.py
+++ b/aas.py
@@ -59,13 +59,6 @@ class GitHub(Resource):
         else:
             abort(400)
 
-
-class Contentful(Resource):
-    def post(self):
-        deploy_static_sticky()
-        return Response(status=200)
-
-
 class Pretix(Resource):
     TOKEN = os.environ["PRETIX_TOKEN"]
 
@@ -139,7 +132,6 @@ aas_api = Api(aas, catch_all_404s=True)
 contentful_endpoint = os.getenv("CONTENTFUL_SECRET_ENDPOINT", "missing")
 
 aas_api.add_resource(GitHub, "/webhook/github")
-aas_api.add_resource(Contentful, "/webhook/contentful/" + contentful_endpoint)
 aas_api.add_resource(Pretix, "/webhook/pretix")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is part of svsticky/sadserver/issues/327

In the new configuration, Contentful calls the CI pipeline, which in turn calls the webhook.
The Contentful endpoint is not necessary anymore and is thus removed.